### PR TITLE
Return a usable return code

### DIFF
--- a/src/Command/ConvertNpmAuditCommand.php
+++ b/src/Command/ConvertNpmAuditCommand.php
@@ -38,10 +38,14 @@ class ConvertNpmAuditCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $output->write(
-            $this->converter->convert(
-                $input->getArgument('input')
-            )
+        $jUnitReport = $this->converter->convert(
+            $input->getArgument('input')
         );
+
+        $output->write($jUnitReport->__toString());
+
+        if (!$jUnitReport->isEmpty()) {
+            return 1;
+        }
     }
 }

--- a/src/Converters/ConverterInterface.php
+++ b/src/Converters/ConverterInterface.php
@@ -2,7 +2,9 @@
 
 namespace TijsVerkoyen\ConvertToJUnitXML\Converters;
 
+use TijsVerkoyen\ConvertToJUnitXML\JUnit\JUnit;
+
 interface ConverterInterface
 {
-    public function convert(string $input);
+    public function convert(string $input): JUnit;
 }

--- a/src/JUnit/JUnit.php
+++ b/src/JUnit/JUnit.php
@@ -15,6 +15,11 @@ class JUnit
         return $this;
     }
 
+    public function isEmpty(): bool
+    {
+        return empty($this->testSuites);
+    }
+
     public function toXML(): \DOMDocument
     {
         $document = new \DOMDocument('1.0', 'utf-8');

--- a/tests/Command/ConvertNpmAuditCommandTest.php
+++ b/tests/Command/ConvertNpmAuditCommandTest.php
@@ -38,5 +38,19 @@ class ConvertNpmAuditCommandTest extends TestCase
 ',
             $this->commandTester->getDisplay()
         );
+        $this->assertEquals(0, $this->commandTester->getStatusCode());
+    }
+
+    public function testExecuteReturnErrorCode()
+    {
+        $this->commandTester->execute(
+            [
+                'input' => file_get_contents(
+                    __DIR__ . '/../assets/npm-audit/multiple.json'
+                ),
+            ]
+        );
+
+        $this->assertEquals(1, $this->commandTester->getStatusCode());
     }
 }


### PR DESCRIPTION
When there are failures the return code should be 1, so builds can fail.