### PR TITLE
Allow Symfony Console 5.x as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "symfony/console": "^4.2"
+        "symfony/console": "^4.2|^5.0"
     },
     "bin": [
         "convert-to-junit-xml"


### PR DESCRIPTION
This commit adds "^5.0" as an option for the "symfony/console" dependency.