### PR TITLE
Add return types

### DIFF
--- a/src/Command/ConvertBashGrepCommand.php
+++ b/src/Command/ConvertBashGrepCommand.php
@@ -22,7 +22,7 @@ class ConvertBashGrepCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('convert:grep')
@@ -36,7 +36,7 @@ class ConvertBashGrepCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $jUnitReport = $this->converter->convert(
             (string) $input->getArgument('input')

--- a/src/Command/ConvertNpmAuditCommand.php
+++ b/src/Command/ConvertNpmAuditCommand.php
@@ -22,7 +22,7 @@ class ConvertNpmAuditCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('convert:npm-audit')
@@ -36,7 +36,7 @@ class ConvertNpmAuditCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($input->hasArgument('input')
             && $input->getArgument('input') !== null

--- a/src/Command/ConvertSensiolabsSecurityCheckCommand.php
+++ b/src/Command/ConvertSensiolabsSecurityCheckCommand.php
@@ -22,7 +22,7 @@ class ConvertSensiolabsSecurityCheckCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('convert:sensiolabs-security-check')
@@ -36,7 +36,7 @@ class ConvertSensiolabsSecurityCheckCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $jUnitReport = $this->converter->convert(
             $input->getArgument('input')

--- a/src/Command/ConvertStandardJsCommand.php
+++ b/src/Command/ConvertStandardJsCommand.php
@@ -22,7 +22,7 @@ class ConvertStandardJsCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('convert:standardjs')
@@ -36,7 +36,7 @@ class ConvertStandardJsCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $jUnitReport = $this->converter->convert(
             $input->getArgument('input')

--- a/src/Command/ConvertStylelintCommand.php
+++ b/src/Command/ConvertStylelintCommand.php
@@ -22,7 +22,7 @@ class ConvertStylelintCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('convert:stylelint')
@@ -36,7 +36,7 @@ class ConvertStylelintCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $jUnitReport = $this->converter->convert(
             $input->getArgument('input')

--- a/src/Converters/Exceptions/InvalidInputException.php
+++ b/src/Converters/Exceptions/InvalidInputException.php
@@ -4,7 +4,7 @@ namespace TijsVerkoyen\ConvertToJUnitXML\Converters\Exceptions;
 
 class InvalidInputException extends \Exception
 {
-    public static function invalidJSON()
+    public static function invalidJSON(): self
     {
         return new self(
             'Invalid input: invalid JSON'


### PR DESCRIPTION
Since Symfony 7, the Command::execute function needs the int return type. Also fixes the return type for configure